### PR TITLE
Added support for different grant_types

### DIFF
--- a/library/Chrisweb/Oauth2.php
+++ b/library/Chrisweb/Oauth2.php
@@ -279,7 +279,7 @@ class Chrisweb_Oauth2
      * @return array
      * @throws Chrisweb_Oauth2_Exception
      */
-    public function requestAccessToken($verificationCode = null, $oauthEndpoint = null, $callbackUrl = null, $clientId = null, $clientSecret = null, $grantType = null, $accessTokenUri = null)
+    public function requestAccessToken($verificationCode = null, $oauthEndpoint = null, $callbackUrl = null, $clientId = null, $clientSecret = null, $grantType = null, $accessTokenUri = null, $username = null, $password = null)
     {
         if (is_null($verificationCode)) $verificationCode = $this->getVerificationCode();
         if (is_null($oauthEndpoint)) $oauthEndpoint = $this->_config->getOauthEndpoint();
@@ -290,7 +290,38 @@ class Chrisweb_Oauth2
         if (is_null(self::$_localHttpClient)) $this->setLocalHttpClient($this->getLocalHttpClient());
         if (is_null($accessTokenUri)) $accessTokenUri = $this->_config->getAccessTokenUri();
 
-        $requiredValuesArray = array('verificationCode', 'clientId', 'clientSecret', 'callbackUrl', 'accessTokenUri', 'oauthEndpoint');
+        if (empty($grantType)) {
+            $grantType = 'authentication_code';
+        }
+
+        $requiredValuesArray = array('clientId', 'clientSecret', 'callbackUrl', 'accessTokenUri', 'oauthEndpoint');
+        $postParametersArray = array(
+            'client_id'   => $clientId,
+            'client_secret' => $clientSecret,
+            'grant_type' => $grantType,
+            'redirect_uri' => $callbackUrl
+        );
+
+        switch ($grantType) {
+            case 'authorization_code':
+                array_push($requiredValuesArray, 'verificationCode');
+                $postParametersArray['code'] = $verificationCode;
+                break;
+            case 'refresh_token':
+                array_push($requiredValuesArray, 'verificationCode');
+                $postParametersArray['refresh_token'] = $verificationCode;
+                break;
+            case 'password':
+                array_push($requiredValuesArray, 'username', 'password');
+                $postParametersArray['username'] = $username;
+                $postParametersArray['password'] = $password;
+                break;
+            case 'client_credentials':
+                break;
+            default:
+                require_once 'Chrisweb/Oauth2/Exception.php';
+                throw new Chrisweb_Oauth2_Exception(sprintf('Unknown grant type: "%s"', $grantType));
+        }
 
         // throw exception if one of the required values is missing
         foreach($requiredValuesArray as $requiredValue) {
@@ -302,17 +333,6 @@ class Chrisweb_Oauth2
 
         if (substr($oauthEndpoint, -1) == '/') $oauthEndpoint = substr($oauthEndpoint, 0, strlen($oauthEndpoint)-1);
         
-        $postParametersArray = array(
-            'client_id'   => $clientId,
-            'client_secret' => $clientSecret,
-            'code' => $verificationCode,
-            'redirect_uri' => $callbackUrl
-        );
-
-        if (!empty($grantType) && !is_null($grantType)) {
-            $postParametersArray['grant_type'] = $grantType;
-        }
-
         self::$_localHttpClient ->resetParameters()
                                 ->setHeaders('Accept-Charset', 'ISO-8859-1,utf-8')
                                 ->setUri($oauthEndpoint.$accessTokenUri)


### PR DESCRIPTION
Hi,

After using your library in a project (connecting to bshaffer's ZF2 OAuth2 server) and adding some stuff to support refresh_tokens, I thought you might want to include it as well. I have tried all grant_types except the "pasword" type, but I'm pretty sure it should work.

They are: 
- authorization_code
  - the default
- refresh_token
  - reuses the $verificationCode parameter
- password
  - uses two new parameters $username and $password
- client_credentials
  - does not a verification credentials.

Please tell me what you think. Also, thanks for the library!

-Martin
